### PR TITLE
add sameSite: false to cookie for it to work cross-origin

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,7 @@ app.use(json());
 app.use(cookieSession({
     signed: false,
     secure: process.env.NODE_ENV !== 'test',
+    sameSite: false,
     expires: new Date((new Date()).getTime() + DEFAULT_COOKIE_EXPIRY)
 }));
 


### PR DESCRIPTION
Add a sameSite: false option to the cookie so browser does not block cross-site cookies.